### PR TITLE
Minimal Permissions

### DIFF
--- a/background.js
+++ b/background.js
@@ -126,26 +126,19 @@ function refineDoi(doi) {
     return doi;
 }
 
-function openUrl(url, openInNewTab) {
+function openUrl(url, openInNewTab, currentTab) {
     if (openInNewTab) {
         browser.tabs.create({ url: url });
     } else {
-        browser.tabs.query({ active: true, currentWindow: true })
-            .then(tabs => {
-                if (tabs[0]) {
-                    browser.tabs.update(tabs[0].id, { url: url });
-                } else {
-                    showNotification("No active tab found to navigate.");
-                }
-            });
+        browser.tabs.update(currentTab.id, { url: url });
     }
 }
 
-function searchAnnasArchive(articleDoi) {
+function searchAnnasArchive(articleDoi, currentTab) {
     browser.storage.sync.get(DEFAULT_OPTS)
         .then(options => {
             const targetUrl = new URL('scidb/' + articleDoi.toLowerCase(), options.url);
-            openUrl(targetUrl.toString(), options.openInNewTab);
+            openUrl(targetUrl.toString(), options.openInNewTab, currentTab);
         })
         .catch(error => {
             console.error('[BACKGROUND] Error opening URL to Anna\'s Archive:', error);
@@ -153,41 +146,32 @@ function searchAnnasArchive(articleDoi) {
         });
 }
 
-function openAnnasArchive() {
-    browser.tabs.query({ active: true, currentWindow: true })
-        .then(async tabs => {
-            if (!tabs || !tabs[0]) {
-                showNotification("No active tab found.");
-                return;
-            }
+function openAnnasArchive(currentTab) {
+  const currentUrl = currentTab.url;
+  var shortTitle = currentTab.title;
+  if (shortTitle.length > 50) {
+      shortTitle = shortTitle.substring(0, 50) + '...';
+  }
+  const website = identifyWebsite(currentUrl);
 
-            const currentTab = tabs[0];
-            const currentUrl = currentTab.url;
-            var shortTitle = currentTab.title;
-            if (shortTitle.length > 50) {
-                shortTitle = shortTitle.substring(0, 50) + '...';
-            }
-            const website = identifyWebsite(currentUrl);
-
-            browser.scripting.executeScript({
-                target: { tabId: currentTab.id },
-                func: extractDoi,
-                args: [website],
-                world: "MAIN"  // needed to access context of the page
-            }).then(results => {
-                const extractedDoi = results[0].result;
-                if (extractedDoi) {
-                    console.log('[BACKGROUND] Successfully extracted DOI:', extractedDoi);
-                    searchAnnasArchive(refineDoi(extractedDoi));
-                } else {
-                    console.warn('[BACKGROUND] Failed to extract article DOI:', currentUrl);
-                    showNotification(`\"${shortTitle}\": could not extract any article DOI.`);
-                }
-            }).catch(error => {
-                console.error('[BACKGROUND] Error extracting article DOI:', error);
-                showNotification(`\"${shortTitle}\": extraction of article DOI failed: ${error.message}`);
-            });
-        });
+  browser.scripting.executeScript({
+      target: { tabId: currentTab.id },
+      func: extractDoi,
+      args: [website],
+      world: "MAIN"  // needed to access context of the page
+  }).then(results => {
+      const extractedDoi = results[0].result;
+      if (extractedDoi) {
+          console.log('[BACKGROUND] Successfully extracted DOI:', extractedDoi);
+          searchAnnasArchive(refineDoi(extractedDoi), currentTab);
+      } else {
+          console.warn('[BACKGROUND] Failed to extract article DOI:', currentUrl);
+          showNotification(`\"${shortTitle}\": could not extract any article DOI.`);
+      }
+  }).catch(error => {
+      console.error('[BACKGROUND] Error extracting article DOI:', error);
+      showNotification(`\"${shortTitle}\": extraction of article DOI failed: ${error.message}`);
+  });
 }
 
 browser.action.onClicked.addListener(openAnnasArchive);

--- a/background.js
+++ b/background.js
@@ -178,7 +178,10 @@ async function openAnnasArchive(currentTab) {
   }
 }
 
-browser.action.onClicked.addListener(currentTab => {
+browser.runtime.onMessage.addListener(({ currentTab }, _sender, sendResponse) => {
     openAnnasArchive(currentTab)
-        .catch(error => showNotification(error.message));
+        .then(() => sendResponse({}))
+        .catch(error => sendResponse({ errorMessage: error.message }));
+    // return `true` to indicate that we're sending a response.
+    return true;
 });

--- a/browser-polyfill.js
+++ b/browser-polyfill.js
@@ -28,7 +28,6 @@
             storage: {
                 sync: ['get', 'set', 'clear']
             },
-            runtime: ['sendMessage', 'getURL'],
             scripting: ['executeScript'],
             notifications: ['create', 'clear']
         };
@@ -40,6 +39,13 @@
             browser.storage.sync.get = promisify(chrome.storage.sync, 'get');
             browser.storage.sync.set = promisify(chrome.storage.sync, 'set');
             browser.storage.sync.clear = promisify(chrome.storage.sync, 'clear');
+        }
+
+        // handle runtime API specially since not all methods need to be promisified
+        if (chrome.runtime) {
+          browser.runtime = browser.runtime || {};
+          browser.runtime.sendMessage = promisify(browser.runtime, 'sendMessage');
+          browser.runtime.getURL = chrome.runtime.getURL;
         }
 
         // handle the rest of the APIs

--- a/browser-polyfill.js
+++ b/browser-polyfill.js
@@ -44,8 +44,9 @@
         // handle runtime API specially since not all methods need to be promisified
         if (chrome.runtime) {
           browser.runtime = browser.runtime || {};
-          browser.runtime.sendMessage = promisify(browser.runtime, 'sendMessage');
+          browser.runtime.sendMessage = promisify(chrome.runtime, 'sendMessage');
           browser.runtime.getURL = chrome.runtime.getURL;
+          browser.runtime.onMessage = chrome.runtime.onMessage;
         }
 
         // handle the rest of the APIs

--- a/manifest.chromium.json
+++ b/manifest.chromium.json
@@ -22,7 +22,6 @@
     },
     "permissions": [
         "storage",
-        "tabs",
         "notifications",
         "scripting",
         "activeTab"

--- a/manifest.chromium.json
+++ b/manifest.chromium.json
@@ -15,14 +15,14 @@
         "128": "icons/128x128.png"
     },
     "action": {
-        "default_title": "To Anna's!"
+        "default_title": "To Anna's!",
+        "default_popup": "popup/popup.html"
     },
     "background": {
         "service_worker": "background-wrapper.js"
     },
     "permissions": [
         "storage",
-        "notifications",
         "scripting",
         "activeTab"
     ],

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -20,7 +20,8 @@
         }
     },
     "action": {
-        "default_title": "To Anna's!"
+        "default_title": "To Anna's!",
+        "default_popup": "popup/popup.html"
     },
     "background": {
         "scripts": [
@@ -29,7 +30,6 @@
     },
     "permissions": [
         "storage",
-        "notifications",
         "scripting",
         "activeTab"
     ],

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -29,7 +29,6 @@
     },
     "permissions": [
         "storage",
-        "tabs",
         "notifications",
         "scripting",
         "activeTab"

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -4,20 +4,20 @@
     <style>
         :root {
             color-scheme: light dark;
-            background-color: light-dark(#cf1748, #ff7e8e);
-            color: light-dark(#fff, #121218);
             font-family: system-ui, sans-serif;
         }
 
         body {
             margin: 0;
+            font-size: 1rem;
         }
 
         #error-message {
+            background-color: light-dark(#ffe8ea, #290b0f);
+            color: light-dark(#000, #fff);
             padding: 1em;
             width: max-content; /* needed for proper sizing in chromium */
-            max-width: 20rem;
-            font-size: 0.8rem;
+            max-width: 25rem;
         }
     </style>
 </head>

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head>
+    <style>
+        :root {
+            color-scheme: light dark;
+            background-color: light-dark(#cf1748, #ff7e8e);
+            color: light-dark(#fff, #121218);
+            font-family: system-ui, sans-serif;
+        }
+
+        body {
+            margin: 0;
+        }
+
+        #error-message {
+            padding: 1em;
+            width: max-content; /* needed for proper sizing in chromium */
+            max-width: 20rem;
+            font-size: 0.8rem;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="error-message" hidden></div>
+</body>
+<script src="../browser-polyfill.js"></script>
+<script type="module" src="./popup.js"></script>
+
+</html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,0 +1,10 @@
+const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true });
+const { errorMessage } = await browser.runtime.sendMessage({ currentTab });
+if (errorMessage) {
+    const errorMessageElement = document.querySelector('#error-message')
+    errorMessageElement.innerText = errorMessage
+    errorMessageElement.removeAttribute('hidden')
+    setTimeout(() => window.close(), 3_500)
+} else {
+    window.close()
+}


### PR DESCRIPTION
First of all thank you for making this extension 💛 

I tend to be suspicious of extensions that require access to all my tabs ^^
However in this case, the `activeTab` is already enough, so it was a no-brainer to remove the `tabs` permission.

Similarly, I get suspicious about the `notifications` permission.
Since it is only used for error handling, it can easily be replaced by showing an error message in the popup:

<img src="https://github.com/user-attachments/assets/925b7ccb-b905-41d5-abd2-b41165eb9fbe" width="50%"><img src="https://github.com/user-attachments/assets/3feede91-4074-44d0-86d2-c8a1b3b2a0df" width="50%">


This required a bit more changes since I needed to refactor the code so that I can send back a response to the popup's message.

Now, Firefox shows that this extension doesn't require any permissions at all 🎉 
![image](https://github.com/user-attachments/assets/abf02a5d-b1f1-49ca-9914-07e12ac694bb)
